### PR TITLE
Tweak col, node spacing rules on Editor

### DIFF
--- a/src/frontend/src/components/TreeNode.vue
+++ b/src/frontend/src/components/TreeNode.vue
@@ -186,7 +186,7 @@ function toggleExpand(value: boolean | null = null): void {
 
 <style scoped>
 .tree-node {
-  padding-left: 20px;
+  padding-left: 5px;
 }
 
 .drop-zone {
@@ -203,7 +203,7 @@ function toggleExpand(value: boolean | null = null): void {
 
 .node-header {
   cursor: pointer;
-  padding: 4px 6px;
+  padding: 0;
   display: flex;
   align-items: center;
   white-space: nowrap;
@@ -232,7 +232,7 @@ function toggleExpand(value: boolean | null = null): void {
 .node-label,
 .node-length,
 .node-content {
-  padding: 5px;
+  padding-right: 8px;
 }
 
 .node-tag {
@@ -241,9 +241,11 @@ function toggleExpand(value: boolean | null = null): void {
 }
 
 .children {
-  border-left: 2px solid rgba(255, 255, 255, 0.2);
-  margin-left: 10px;
-  padding-left: 10px;
+  border-left: 2px solid rgba(100, 100, 100, 0.2);
+  margin-left: 3px;
+  padding-left: 8px;
+  /* adds spacing after deeply nested items */
+  padding-bottom: 2px;
 }
 
 .draggable {
@@ -257,6 +259,7 @@ function toggleExpand(value: boolean | null = null): void {
     font-size: 0.9rem;
   }
   .children {
+    margin-left: 0px !important;
     margin-left: 5px;
     padding-left: 8px;
   }

--- a/src/frontend/src/components/UploadCard.vue
+++ b/src/frontend/src/components/UploadCard.vue
@@ -482,6 +482,11 @@ function handlePastedContent(): void {
   padding: 20px;
 }
 
+.paste-zone :deep(.v-textarea) {
+  overflow: scroll;
+  max-height: 80dvh;
+}
+
 .paste-textarea :deep(.v-field) {
   border-radius: 8px;
 }

--- a/src/frontend/src/views/EditorView.vue
+++ b/src/frontend/src/views/EditorView.vue
@@ -273,7 +273,7 @@
         </v-tabs>
       </v-col>
 
-      <v-col cols="12" md="6">
+      <v-col cols="12" md class="center-col">
         <div
           :style="{ position: 'absolute', left: `${menuX}px`, top: `${menuY}px` }"
           ref="activatorRef"
@@ -293,7 +293,7 @@
         </div>
       </v-col>
 
-      <v-col cols="12" md="4">
+      <v-col cols="12" md="4" class="right-col">
         <div class="byte-grid-container" ref="bytesRef">
           <div class="byte-grid" v-if="store.tree.length > 0">
             <span
@@ -841,6 +841,21 @@ onUpdated(() => {
 
 .crashed-thin {
   color: red;
+}
+
+/* column spacing */
+
+/* have center col take up all remaining space */
+.center-col {
+  overflow: scroll;
+}
+/* prevent right col with byte-grid from taking too little space on medium
+  screens and too much space on wide screens */
+@media (min-width: 960px) {
+  .right-col {
+    min-width: 26em;
+    max-width: 32em;
+  }
 }
 
 .byte-grid-container {


### PR DESCRIPTION
- Significantly lowers padding & margin spacing in the editor view to make better use of browser window space.
- Fixes some editor view alignment issues, like the top node not being as far left as possible and expandable nodes less indented than non-expandable nodes
- Set min- and max-width for the byte-grid column to render more nicely on wide and medium screens
- Fix paste window bug of extending beyond window limits on long inputs